### PR TITLE
Added op-equals and comparison operators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multiset"
-version = "0.0.5"
+version = "0.0.6"
 repository = "https://github.com/jmitchell/multiset"
 description = "Multisets/bags"
 keywords = ["multiset","bag","data-structure","collection","count"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multiset"
-version = "0.0.6"
+version = "0.0.7"
 repository = "https://github.com/jmitchell/multiset"
 description = "Multisets/bags"
 keywords = ["multiset","bag","data-structure","collection","count"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multiset"
-version = "0.0.4"
+version = "0.0.5"
 repository = "https://github.com/jmitchell/multiset"
 description = "Multisets/bags"
 keywords = ["multiset","bag","data-structure","collection","count"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Multiset [![Build Status](https://travis-ci.org/jmitchell/multiset.png?branch=master)](https://travis-ci.org/jmitchell/multiset)
+Copyright (c) 2015 Jake Mitchell
 
-TODO
+This is a Rust implementation of Multisets (bags) using
+`HashMap`. Please see the documentation for details.
+
+This program is available under the "Apache License". Please
+see the file `LICENSE` in this distribution for license terms.

--- a/src/multiset.rs
+++ b/src/multiset.rs
@@ -372,6 +372,16 @@ impl<T, U> Add<U> for HashMultiSet<T> where
     U: AsRef<HashMultiSet<T>>
 {
     type Output = HashMultiSet<T>;
+    fn add(self, rhs: U) ->  HashMultiSet<T> {
+        &self + rhs.as_ref()
+    }
+}
+
+impl<'a, T, U> Add<U> for &'a HashMultiSet<T> where
+    T: Eq + Hash + Clone,
+    U: AsRef<HashMultiSet<T>>
+{
+    type Output = HashMultiSet<T>;
 
     /// Combine two `HashMultiSet`s by adding the number of each
     /// distinct element.
@@ -437,6 +447,16 @@ impl<T, U> AddAssign<U> for HashMultiSet<T> where
 }
 
 impl<T, U> Sub<U> for HashMultiSet<T> where
+    T: Eq + Hash + Clone,
+    U: AsRef<HashMultiSet<T>>
+{
+    type Output = HashMultiSet<T>;
+    fn sub(self, rhs: U) ->  HashMultiSet<T> {
+        &self - rhs.as_ref()
+    }
+}
+
+impl<'a, T, U> Sub<U> for &'a HashMultiSet<T> where
     T: Eq + Hash + Clone,
     U: AsRef<HashMultiSet<T>>
 {

--- a/src/multiset.rs
+++ b/src/multiset.rs
@@ -14,6 +14,50 @@ pub struct HashMultiSet<K>
     elem_counts: HashMap<K, usize>
 }
 
+/// Test the degree to which the RHS is contained by the LHS.
+/// * A result of `Equal` means that the LHS exactly
+/// matches on all RHS elements.
+/// * A result of `Greater` means that the LHS contains
+/// all present RHS elements and overcontains at least one.
+/// * A result of `Less` means only that the containment
+/// does not hold.
+fn containment<T>(lhs: &HashMultiSet<T>,
+                  rhs: &HashMultiSet<T>) -> Ordering
+    where T: Eq + Hash
+{
+    let mut result = Ordering::Equal;
+    for val in rhs.distinct_elements() {
+        let nlhs = match lhs.elem_counts.get(&val) {
+            None => 0,
+            Some(np) => *np
+        };
+        if nlhs == 0 {
+            return Ordering::Less;
+        };
+        let nrhs = *rhs.elem_counts.get(&val).unwrap();
+        if nrhs > nlhs {
+            return Ordering::Less;
+        } else if nrhs < nlhs {
+            result = Ordering::Greater;
+        };
+    };
+    result
+}
+
+#[test]
+fn test_containment() {
+    let s1: HashMultiSet<isize> = FromIterator::from_iter(vec![1,2,3]);
+    let s2: HashMultiSet<isize> = FromIterator::from_iter(vec![1,1,4]);
+    let s3: HashMultiSet<isize> = FromIterator::from_iter(vec![2,3]);
+    let s4: HashMultiSet<isize> = FromIterator::from_iter(vec![1,4]);
+    assert_eq!(Ordering::Equal, containment(&s1, &s1));
+    assert_eq!(Ordering::Less, containment(&s1, &s2));
+    assert_eq!(Ordering::Less, containment(&s2, &s1));
+    assert_eq!(Ordering::Equal, containment(&s1, &s3));
+    assert_eq!(Ordering::Less, containment(&s3, &s1));
+    assert_eq!(Ordering::Greater, containment(&s2, &s4));
+}
+
 impl<K> HashMultiSet<K> where
     K: Eq + Hash
 {
@@ -226,6 +270,95 @@ impl<K> HashMultiSet<K> where
             .get(&val)
             .map_or(0, |x| *x)
     }
+    /// MultiSets are partial-ordered by containment: if
+    /// they are equal, they are `Equal`; if one is a proper
+    /// subset of the other they are `Less` or `Greater`;
+    /// otherwise they are unordered. This function is
+    /// useful in implementing `PartialOrd` as containment
+    /// ordering if desired.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use multiset::HashMultiSet;
+    /// use std::iter::FromIterator;
+    /// use std::cmp::Ordering;
+    ///
+    /// let s1: HashMultiSet<isize> = FromIterator::from_iter(vec![1,2,3]);
+    /// let s2: HashMultiSet<isize> = FromIterator::from_iter(vec![1,1,4]);
+    /// let s3: HashMultiSet<isize> = FromIterator::from_iter(vec![2,3]);
+    /// let s4: HashMultiSet<isize> = FromIterator::from_iter(vec![1,1,2,3]);
+    /// assert_eq!(None, s1.partial_cmp(&s2));
+    /// assert_eq!(Some(Ordering::Less), s3.partial_cmp(&s1));    
+    /// assert_eq!(Some(Ordering::Less), s1.partial_cmp(&s4));
+    /// assert_eq!(Some(Ordering::Greater), s1.partial_cmp(&s3));
+    /// assert_eq!(Some(Ordering::Equal), s1.partial_cmp(&s1));
+    /// assert_eq!(Some(Ordering::Greater), s4.partial_cmp(&s1));
+    /// ```
+    pub fn partial_cmp(&self, other: &HashMultiSet<K>) -> Option<Ordering> {
+        match containment(self, other) {
+            Ordering::Less => {
+                match containment(other, self) {
+                    Ordering::Less => None,
+                    _ => Some(Ordering::Less)
+                }
+            },
+            Ordering::Equal => {
+                match containment(other, self) {
+                    Ordering::Less => Some(Ordering::Greater),
+                    Ordering::Equal => Some(Ordering::Equal),
+                    Ordering::Greater => panic!("=> ordering observed")
+                }
+            },
+            Ordering::Greater => Some(Ordering::Greater)
+        }
+    }
+
+    /// The given multiset properly contains this one.  This
+    /// is computed more efficiently than with
+    /// `partial_cmp()` in some cases.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use multiset::HashMultiSet;
+    /// use std::iter::FromIterator;
+    ///
+    /// let s1: HashMultiSet<isize> = FromIterator::from_iter(vec![1,2,3]);
+    /// let s2: HashMultiSet<isize> = FromIterator::from_iter(vec![1,1,4]);
+    /// let s3: HashMultiSet<isize> = FromIterator::from_iter(vec![2,3]);
+    /// assert!(s1.is_submultiset(&s1));
+    /// assert!(s3.is_submultiset(&s1));
+    /// assert!(!s1.is_submultiset(&s2));
+    /// assert!(!s2.is_submultiset(&s1));
+    /// assert!(!s1.is_submultiset(&s3));
+    /// ```
+    pub fn is_submultiset(&self, other: &HashMultiSet<K>) -> bool {
+        containment(other, self) != Ordering::Less
+    }
+
+    /// The given multiset properly contains this one.
+    /// That is, every element of this multiset is
+    /// is in the given multiset, plus at least one more.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use multiset::HashMultiSet;
+    /// use std::iter::FromIterator;
+    ///
+    /// let s1: HashMultiSet<isize> = FromIterator::from_iter(vec![1,2,3]);
+    /// let s2: HashMultiSet<isize> = FromIterator::from_iter(vec![1,1,4]);
+    /// let s3: HashMultiSet<isize> = FromIterator::from_iter(vec![2,3]);
+    /// assert!(s3.is_proper_submultiset(&s1));
+    /// assert!(!s1.is_proper_submultiset(&s1));
+    /// assert!(!s1.is_proper_submultiset(&s2));
+    /// assert!(!s2.is_proper_submultiset(&s1));
+    /// assert!(!s1.is_proper_submultiset(&s3));
+    /// ```
+    pub fn is_proper_submultiset(&self, other: &HashMultiSet<K>) -> bool {
+        self.partial_cmp(other) == Some(Ordering::Less)
+    }
 }
 
 impl<T> Add for HashMultiSet<T> where
@@ -392,138 +525,6 @@ impl<T> PartialEq for HashMultiSet<T> where
 }
 
 impl <T> Eq for HashMultiSet<T> where T: Eq + Hash + Clone {}
-
-/// Test the degree to which the RHS is contained by the LHS.
-/// * A result of `Equal` means that the LHS exactly
-/// matches on all RHS elements.
-/// * A result of `Greater` means that the LHS contains
-/// all present RHS elements and overcontains at least one.
-/// * A result of `Less` means only that the containment
-/// does not hold.
-fn containment<T>(lhs: &HashMultiSet<T>,
-                  rhs: &HashMultiSet<T>) -> Ordering
-    where T: Eq + Hash + Clone
-{
-    let mut result = Ordering::Equal;
-    for val in rhs.distinct_elements() {
-        let nlhs = lhs.count_of(val.clone());
-        if nlhs == 0 {
-            return Ordering::Less;
-        };
-        let nrhs = rhs.count_of(val.clone());
-        if nrhs > nlhs {
-            return Ordering::Less;
-        } else if nrhs < nlhs {
-            result = Ordering::Greater;
-        };
-    };
-    result
-}
-
-#[test]
-fn test_containment() {
-    let s1: HashMultiSet<isize> = FromIterator::from_iter(vec![1,2,3]);
-    let s2: HashMultiSet<isize> = FromIterator::from_iter(vec![1,1,4]);
-    let s3: HashMultiSet<isize> = FromIterator::from_iter(vec![2,3]);
-    let s4: HashMultiSet<isize> = FromIterator::from_iter(vec![1,4]);
-    assert_eq!(Ordering::Equal, containment(&s1, &s1));
-    assert_eq!(Ordering::Less, containment(&s1, &s2));
-    assert_eq!(Ordering::Less, containment(&s2, &s1));
-    assert_eq!(Ordering::Equal, containment(&s1, &s3));
-    assert_eq!(Ordering::Less, containment(&s3, &s1));
-    assert_eq!(Ordering::Greater, containment(&s2, &s4));
-}
-
-impl<T> PartialOrd for HashMultiSet<T> where
-    T: Eq + Hash + Clone
-{
-    /// MultiSets are partial-ordered by containment: if they
-    /// are equal, they are `Equal`; if one is a proper subset
-    /// of the other they are `Less` or `Greater`; otherwise
-    /// they are unordered.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use multiset::HashMultiSet;
-    /// use std::iter::FromIterator;
-    /// use std::cmp::Ordering;
-    ///
-    /// let s1: HashMultiSet<isize> = FromIterator::from_iter(vec![1,2,3]);
-    /// let s2: HashMultiSet<isize> = FromIterator::from_iter(vec![1,1,4]);
-    /// let s3: HashMultiSet<isize> = FromIterator::from_iter(vec![2,3]);
-    /// let s4: HashMultiSet<isize> = FromIterator::from_iter(vec![1,1,2,3]);
-    /// assert_eq!(None, s1.partial_cmp(&s2));
-    /// assert_eq!(Some(Ordering::Less), s3.partial_cmp(&s1));    
-    /// assert_eq!(Some(Ordering::Less), s1.partial_cmp(&s4));
-    /// assert_eq!(Some(Ordering::Greater), s1.partial_cmp(&s3));
-    /// assert_eq!(Some(Ordering::Equal), s1.partial_cmp(&s1));
-    /// assert_eq!(Some(Ordering::Greater), s4.partial_cmp(&s1));
-    /// ```
-    fn partial_cmp(&self, other: &HashMultiSet<T>) -> Option<Ordering> {
-        match containment(self, other) {
-            Ordering::Less => {
-                match containment(other, self) {
-                    Ordering::Less => None,
-                    _ => Some(Ordering::Less)
-                }
-            },
-            Ordering::Equal => {
-                match containment(other, self) {
-                    Ordering::Less => Some(Ordering::Greater),
-                    Ordering::Equal => Some(Ordering::Equal),
-                    Ordering::Greater => panic!("=> ordering observed")
-                }
-            },
-            Ordering::Greater => Some(Ordering::Greater)
-        }
-    }
-
-    /// The RHS contains the LHS. This is computed more efficiently
-    /// than with `partial_cmp()` in some cases.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use multiset::HashMultiSet;
-    /// use std::iter::FromIterator;
-    ///
-    /// let s1: HashMultiSet<isize> = FromIterator::from_iter(vec![1,2,3]);
-    /// let s2: HashMultiSet<isize> = FromIterator::from_iter(vec![1,1,4]);
-    /// let s3: HashMultiSet<isize> = FromIterator::from_iter(vec![2,3]);
-    /// assert!(s1 <= s1);
-    /// assert!(s3 <= s1);
-    /// assert!(!(s1 <= s2));
-    /// assert!(!(s2 <= s1));
-    /// assert!(!(s1 <= s3));
-    /// ```
-    fn le(&self, other: &HashMultiSet<T>) -> bool {
-        containment(other, self) != Ordering::Less
-    }
-
-    /// The LHS contains the RHS. This is computed more efficiently
-    /// than with `partial_cmp()` in some cases.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use multiset::HashMultiSet;
-    /// use std::iter::FromIterator;
-    ///
-    /// let s1: HashMultiSet<isize> = FromIterator::from_iter(vec![1,2,3]);
-    /// let s2: HashMultiSet<isize> = FromIterator::from_iter(vec![1,1,4]);
-    /// let s3: HashMultiSet<isize> = FromIterator::from_iter(vec![2,3]);
-    /// assert!(s1 >= s1);
-    /// assert!(s1 >= s3);
-    /// assert!(!(s2 >= s1));
-    /// assert!(!(s1 >= s2));
-    /// assert!(!(s3 >= s1));
-    /// ```
-    fn ge(&self, other: &HashMultiSet<T>) -> bool {
-        containment(self, other) != Ordering::Less
-    }
-
-}
 
 impl<A> FromIterator<A> for HashMultiSet<A> where
     A: Eq + Hash

--- a/src/multiset.rs
+++ b/src/multiset.rs
@@ -361,8 +361,15 @@ impl<K> HashMultiSet<K> where
     }
 }
 
-impl<T> Add for HashMultiSet<T> where
-    T: Eq + Hash + Clone
+impl<T> AsRef<HashMultiSet<T>> for HashMultiSet<T> {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl<T, U> Add<U> for HashMultiSet<T> where
+    T: Eq + Hash + Clone,
+    U: AsRef<HashMultiSet<T>>
 {
     type Output = HashMultiSet<T>;
 
@@ -384,7 +391,8 @@ impl<T> Add for HashMultiSet<T> where
     /// assert_eq!(1, combined.count_of(4));
     /// assert_eq!(0, combined.count_of(5));
     /// ```
-    fn add(self, rhs: HashMultiSet<T>) ->  HashMultiSet<T> {
+    fn add(self, rhs: U) ->  HashMultiSet<T> {
+        let rhs = rhs.as_ref();
         let mut ret: HashMultiSet<T> = HashMultiSet::new();
         for val in self.distinct_elements() {
             let count = self.count_of((*val).clone());
@@ -398,8 +406,9 @@ impl<T> Add for HashMultiSet<T> where
     }
 }
 
-impl<T> AddAssign for HashMultiSet<T> where
-    T: Eq + Hash + Clone
+impl<T, U> AddAssign<U> for HashMultiSet<T> where
+    T: Eq + Hash + Clone,
+    U: AsRef<HashMultiSet<T>>
 {
     /// Insert the elements of one `HashMultiSet` into another.
     ///
@@ -418,7 +427,8 @@ impl<T> AddAssign for HashMultiSet<T> where
     /// assert_eq!(1, lhs.count_of(4));
     /// assert_eq!(0, lhs.count_of(5));
     /// ```
-    fn add_assign(&mut self, rhs: HashMultiSet<T>) {
+    fn add_assign(&mut self, rhs: U) {
+        let rhs = rhs.as_ref();
         for val in rhs.distinct_elements() {
             let count = rhs.count_of((*val).clone());
             self.insert_times((*val).clone(), count);
@@ -426,8 +436,9 @@ impl<T> AddAssign for HashMultiSet<T> where
     }
 }
 
-impl<T> Sub for HashMultiSet<T> where
-    T: Eq + Hash + Clone
+impl<T, U> Sub<U> for HashMultiSet<T> where
+    T: Eq + Hash + Clone,
+    U: AsRef<HashMultiSet<T>>
 {
     type Output = HashMultiSet<T>;
 
@@ -450,7 +461,8 @@ impl<T> Sub for HashMultiSet<T> where
     /// assert_eq!(1, combined.count_of(3));
     /// assert_eq!(0, combined.count_of(4));
     /// ```
-    fn sub(self, rhs: HashMultiSet<T>) ->  HashMultiSet<T> {
+    fn sub(self, rhs: U) ->  HashMultiSet<T> {
+        let rhs = rhs.as_ref();
         let mut ret = self.clone();
         for val in rhs.distinct_elements() {
             let count = rhs.count_of((*val).clone());
@@ -460,8 +472,9 @@ impl<T> Sub for HashMultiSet<T> where
     }
 }
 
-impl<T> SubAssign for HashMultiSet<T> where
-    T: Eq + Hash + Clone
+impl<T, U> SubAssign<U> for HashMultiSet<T> where
+    T: Eq + Hash + Clone,
+    U: AsRef<HashMultiSet<T>>
 {
     /// Remove the elements of one `HashMultiSet` from another
     /// using `-`.
@@ -480,7 +493,8 @@ impl<T> SubAssign for HashMultiSet<T> where
     /// assert_eq!(1, lhs.count_of(3));
     /// assert_eq!(0, lhs.count_of(4));
     /// ```
-    fn sub_assign(&mut self, rhs: HashMultiSet<T>) {
+    fn sub_assign(&mut self, rhs: U) {
+        let rhs = rhs.as_ref();
         for val in rhs.distinct_elements() {
             let count = rhs.count_of((*val).clone());
             self.remove_times((*val).clone(), count);

--- a/src/multiset.rs
+++ b/src/multiset.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap};
 use std::collections::hash_map::{Entry,Keys};
 use std::hash::{Hash};
 use std::iter::{FromIterator,IntoIterator};
-use std::ops::{Add, Sub};
+use std::ops::{Add, AddAssign, Sub, SubAssign};
 
 /// A hash-based multiset.
 #[derive(Clone)]
@@ -264,6 +264,34 @@ impl<T> Add for HashMultiSet<T> where
     }
 }
 
+impl<T> AddAssign for HashMultiSet<T> where
+    T: Eq + Hash + Clone
+{
+    /// Insert the elements of one `HashMultiSet` into another.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use multiset::HashMultiSet;
+    /// use std::iter::FromIterator;
+    ///
+    /// let mut lhs: HashMultiSet<isize> = FromIterator::from_iter(vec![1,2,3]);
+    /// let rhs: HashMultiSet<isize> = FromIterator::from_iter(vec![1,1,4]);
+    /// lhs += rhs;
+    /// assert_eq!(3, lhs.count_of(1));
+    /// assert_eq!(1, lhs.count_of(2));
+    /// assert_eq!(1, lhs.count_of(3));
+    /// assert_eq!(1, lhs.count_of(4));
+    /// assert_eq!(0, lhs.count_of(5));
+    /// ```
+    fn add_assign(&mut self, rhs: HashMultiSet<T>) {
+        for val in rhs.distinct_elements() {
+            let count = rhs.count_of((*val).clone());
+            self.insert_times((*val).clone(), count);
+        }
+    }
+}
+
 impl<T> Sub for HashMultiSet<T> where
     T: Eq + Hash + Clone
 {
@@ -295,6 +323,34 @@ impl<T> Sub for HashMultiSet<T> where
             ret.remove_times((*val).clone(), count);
         }
         ret
+    }
+}
+
+impl<T> SubAssign for HashMultiSet<T> where
+    T: Eq + Hash + Clone
+{
+    /// Remove the elements of one `HashMultiSet` from another
+    /// using `-`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use multiset::HashMultiSet;
+    /// use std::iter::FromIterator;
+    ///
+    /// let mut lhs: HashMultiSet<isize> = FromIterator::from_iter(vec![1,2,3]);
+    /// let rhs: HashMultiSet<isize> = FromIterator::from_iter(vec![1,1,4]);
+    /// lhs -= rhs;
+    /// assert_eq!(0, lhs.count_of(1));
+    /// assert_eq!(1, lhs.count_of(2));
+    /// assert_eq!(1, lhs.count_of(3));
+    /// assert_eq!(0, lhs.count_of(4));
+    /// ```
+    fn sub_assign(&mut self, rhs: HashMultiSet<T>) {
+        for val in rhs.distinct_elements() {
+            let count = rhs.count_of((*val).clone());
+            self.remove_times((*val).clone(), count);
+        }
     }
 }
 


### PR DESCRIPTION
For my current project I needed to be able to do `<=` and wanted to be able to do `+=` and `-=` and the other comparison operators. These commits provide that functionality.

If you could accept this pull request and then update Cargo I would be grateful. Thanks!