### PR TITLE
Publish 0.0.5 to crates.io?

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multiset"
-version = "0.0.4"
+version = "0.0.5"
 repository = "https://github.com/jmitchell/multiset"
 description = "Multisets/bags"
 keywords = ["multiset","bag","data-structure","collection","count"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
-# Multiset [![Build Status](https://travis-ci.org/jmitchell/multiset.png?branch=master)](https://travis-ci.org/jmitchell/multiset)
+# Multiset [![Crates.io](https://img.shields.io/crates/v/multiset.svg?maxAge=86400)](https://crates.io/crates/multiset) [![Docs](https://docs.rs/multiset/badge.svg)](https://docs.rs/multiset) [![Build Status](https://travis-ci.org/jmitchell/multiset.svg?branch=master)](https://travis-ci.org/jmitchell/multiset)
 
-TODO
+A multiset is an unordered collection of values. They are also known as bags.
+
+Unlike sets where each value is either included or not, multisets permit duplicates. Consequently, they're useful for maintaining a count of distinct values.
+
+See the documentation of [HashMultiSet](https://docs.rs/multiset/0.0.5/multiset/struct.HashMultiSet.html) for examples.
+
+## License
+Licensed under Apache License, Version 2.0, ([LICENSE](LICENSE) or http://www.apache.org/licenses/LICENSE-2.0).
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
I'd quite like to use the latest version in a crate I'm publishing, so would appreciate if a new version could be published to crates.io!

I bumped the version number accordingly, and added links to crates.io and docs.rs to the readme.