### PR TITLE
Implement union, intersection, union_counts, and intersection_counts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,4 +15,4 @@
 
 mod multiset;
 
-pub use multiset::{HashMultiSet, Iter};
+pub use multiset::{HashMultiSet, Intersection, IntersectionCounts, Iter, Union, UnionCounts};

--- a/src/multiset.rs
+++ b/src/multiset.rs
@@ -448,6 +448,8 @@ where
     }
 }
 
+/// An iterator over the union of two structs. See [HashMultiSet::union] for
+/// more details.
 pub struct Union<'a, K> {
     set1_iter: hash_map::Iter<'a, K, usize>,
     set2_iter: hash_map::Iter<'a, K, usize>,
@@ -488,6 +490,8 @@ where
     }
 }
 
+/// An iterator over the intersection of two structs. See
+/// [HashMultiSet::intersection] for more details.
 pub struct Intersection<'a, K> {
     set1_iter: hash_map::Iter<'a, K, usize>,
     set2: &'a HashMultiSet<K>,
@@ -518,6 +522,8 @@ where
     }
 }
 
+/// An iterator over the union of two structs. See [HashMultiSet::union] for
+/// more details.
 pub struct UnionCounts<'a, K> {
     set1: &'a HashMultiSet<K>,
     set2: &'a HashMultiSet<K>,
@@ -545,6 +551,8 @@ where
     }
 }
 
+/// An iterator over the intersection of two structs. See
+/// [HashMultiSet::intersection] for more details.
 pub struct IntersectionCounts<'a, K> {
     set2: &'a HashMultiSet<K>,
     set1_iter: hash_map::Iter<'a, K, usize>,

--- a/src/multiset.rs
+++ b/src/multiset.rs
@@ -429,13 +429,13 @@ where
     ///
     /// let set1: HashMultiSet<_> = [1, 1, 2].iter().cloned().collect();
     /// let set2: HashMultiSet<_> = [2, 2, 3].iter().cloned().collect();
-    /// let set_union: HashMultiSet<_> = set1
+    /// let set_intersection: HashMultiSet<_> = set1
     ///     .intersection_counts(&set2)
     ///     .map(|(&key, count)| (key, count))
     ///     .collect();
-    /// assert_eq!(set_union.count_of(&1), 0);
-    /// assert_eq!(set_union.count_of(&2), 1);
-    /// assert_eq!(set_union.count_of(&3), 0);
+    /// assert_eq!(set_intersection.count_of(&1), 0);
+    /// assert_eq!(set_intersection.count_of(&2), 1);
+    /// assert_eq!(set_intersection.count_of(&3), 0);
     /// ```
     pub fn intersection_counts<'a>(
         &'a self,
@@ -1031,55 +1031,55 @@ mod test_multiset {
     fn test_intersection_counts() {
         let set1: HashMultiSet<_> = [1, 1].iter().cloned().collect();
         let set2: HashMultiSet<_> = [1, 1, 1].iter().cloned().collect();
-        let set_union: HashMultiSet<_> = set1
+        let set_intersection: HashMultiSet<_> = set1
             .intersection_counts(&set2)
             .map(|(&key, count)| (key, count))
             .collect();
-        assert_eq!(set_union.count_of(&1), 2);
-        assert_eq!(set_union.len(), 2);
+        assert_eq!(set_intersection.count_of(&1), 2);
+        assert_eq!(set_intersection.len(), 2);
 
         let set1: HashMultiSet<_> = [1, 1].iter().cloned().collect();
         let set2: HashMultiSet<_> = [2, 2, 2].iter().cloned().collect();
-        let set_union: HashMultiSet<_> = set1
+        let set_intersection: HashMultiSet<_> = set1
             .intersection_counts(&set2)
             .map(|(&key, count)| (key, count))
             .collect();
-        assert_eq!(set_union.count_of(&1), 0);
-        assert_eq!(set_union.count_of(&2), 0);
-        assert_eq!(set_union.len(), 0);
+        assert_eq!(set_intersection.count_of(&1), 0);
+        assert_eq!(set_intersection.count_of(&2), 0);
+        assert_eq!(set_intersection.len(), 0);
 
         let set1: HashMultiSet<_> = [1, 1, 2].iter().cloned().collect();
         let set2: HashMultiSet<_> = [1, 1, 3].iter().cloned().collect();
-        let set_union: HashMultiSet<_> = set1
+        let set_intersection: HashMultiSet<_> = set1
             .intersection_counts(&set2)
             .map(|(&key, count)| (key, count))
             .collect();
-        assert_eq!(set_union.count_of(&1), 2);
-        assert_eq!(set_union.count_of(&2), 0);
-        assert_eq!(set_union.count_of(&3), 0);
-        assert_eq!(set_union.len(), 2);
+        assert_eq!(set_intersection.count_of(&1), 2);
+        assert_eq!(set_intersection.count_of(&2), 0);
+        assert_eq!(set_intersection.count_of(&3), 0);
+        assert_eq!(set_intersection.len(), 2);
 
         let set1: HashMultiSet<_> = [1, 1, 2, 3].iter().cloned().collect();
         let empty_array: [u32; 0] = [];
         let set2: HashMultiSet<_> = empty_array.iter().cloned().collect();
-        let set_union: HashMultiSet<_> = set1
+        let set_intersection: HashMultiSet<_> = set1
             .intersection_counts(&set2)
             .map(|(&key, count)| (key, count))
             .collect();
-        assert_eq!(set_union.count_of(&1), 0);
-        assert_eq!(set_union.count_of(&2), 0);
-        assert_eq!(set_union.count_of(&3), 0);
-        assert_eq!(set_union.len(), 0);
+        assert_eq!(set_intersection.count_of(&1), 0);
+        assert_eq!(set_intersection.count_of(&2), 0);
+        assert_eq!(set_intersection.count_of(&3), 0);
+        assert_eq!(set_intersection.len(), 0);
 
         let set1: HashMultiSet<_> = [1, 1, 2, 3].iter().cloned().collect();
         let set2: HashMultiSet<_> = [1, 1, 2, 3].iter().cloned().collect();
-        let set_union: HashMultiSet<_> = set1
+        let set_intersection: HashMultiSet<_> = set1
             .intersection_counts(&set2)
             .map(|(&key, count)| (key, count))
             .collect();
-        assert_eq!(set_union.count_of(&1), 2);
-        assert_eq!(set_union.count_of(&2), 1);
-        assert_eq!(set_union.count_of(&3), 1);
-        assert_eq!(set_union.len(), 4);
+        assert_eq!(set_intersection.count_of(&1), 2);
+        assert_eq!(set_intersection.count_of(&2), 1);
+        assert_eq!(set_intersection.count_of(&3), 1);
+        assert_eq!(set_intersection.len(), 4);
     }
 }


### PR DESCRIPTION
The `union` and `union_counts` methods return iterators that yield elements the maximum number of times they appear in either set. This is different from the previously implemented `Add` trait, which yields each element the combined number of times it appears in both sets.

The `intersection` and `intersection_counts` methods return iterators that yield elements the minimum number of times they appear in either set. This is distinct from the previously implemented `Sub` trait, which yields each element the number of times it appears in the first set less the number of times it appears in the second.

The difference between the plain variants and the `_counts` variants is that the former yields only the elements (repeated the correct number of times) while the latter yields a tuple of an element and the count of that element.

---

This closes #17.

I'm totally willing to take feedback on implementation, naming, or even whether you want to include all of these changes or not.

Let me know what you think!